### PR TITLE
Delete registered key on unpersisted unmount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,11 @@ function log(...args){
   return this;
 }
 
+function omit(obj, key) {
+  return Object.keys(obj).reduce( (o, k) => {
+    return k === key ? o : { ...o, [k]: obj[k] };
+  });
+}
 
 export class Root extends Component{
   static propTypes = {
@@ -155,12 +160,12 @@ export function localReducer(state = {registered: {}}, action){
       ...state,
       // we can leave the data in place
       [payload.ident] : payload.persist ? state[payload.ident] : undefined,
-      registered : {
+      registered : payload.persist ? {
         ...state.registered,
         [payload.ident]: {
           reducer: identity // signals that this is unmounted
         }
-      }
+      } : omit(state.registered, payload.ident)
     };
   }
 


### PR DESCRIPTION
There may be a good reason I am missing, but if !persist, I think we can omit the key from the reducer registry altogether. Otherwise, in the course of an app that generates many dynamic local state (e.g. a bunch of forms), we end up with a very heavily populated registry, and even if the reducer is just x => x, we end up having to enumerate over every key, run x => x, compare x === x, and move on.