### PR TITLE
Add ability to define whether action is local

### DIFF
--- a/lib/decorator.js
+++ b/lib/decorator.js
@@ -116,13 +116,15 @@ function local() {
             value: whenUndefined(storeState.local.get(id), getInitial(_this.props))
           };
         }(), _this.$ = function (action) {
+          var useLocal = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
+
           // 'localize' an event. super convenient for making actions 'local' to this component
           return _extends({}, action, {
             type: _this.state.id + ':' + action.type,
             meta: _extends({}, action.meta || {}, {
               ident: _this.state.id,
               type: action.type,
-              local: true
+              local: useLocal
             })
           });
         }, _this._setState = function (state) {

--- a/src/decorator.js
+++ b/src/decorator.js
@@ -87,7 +87,7 @@ export default function local({
         }
       })()
 
-      $ = action => {
+      $ = (action, useLocal = true) => {
         // 'localize' an event. super convenient for making actions 'local' to this component
         return  {
           ...action,
@@ -96,7 +96,7 @@ export default function local({
             ...action.meta || {},
             ident: this.state.id,
             type: action.type,
-            local: true
+            local: useLocal
           }
         }
       }


### PR DESCRIPTION
When generating an action with $ can use a second argument, defaulting to true, that specifies if the local property is true.

This was useful for me because I want all reducers (local and global) to be able to listen to dispatched local actions so I can update arbitrary info. Without this change only non redux-react-local reducers could listen to those actions.