### PR TITLE
update prop-types

### DIFF
--- a/src/decorator.js
+++ b/src/decorator.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types';
 
 const isBrowserLike = typeof navigator !== 'undefined'
 


### PR DESCRIPTION
from react 15 React.PropTypes is deprecated and moved to prop-types package
and for react 16 PropTypes is removed from 'react' package. 
